### PR TITLE
Fix sound player ui

### DIFF
--- a/lib/src/ui/sound_player_ui.dart
+++ b/lib/src/ui/sound_player_ui.dart
@@ -420,7 +420,6 @@ class SoundPlayerUIState extends State<SoundPlayerUI> {
         throw TrackLoaderException;
       }
     } on MediaFormatException catch (exception, st) {
-      Log.d(green('Transitioning = false'));
       Log.e(
         'Error occured loading the track: ${exception.toString()}',
         error: exception,
@@ -445,7 +444,6 @@ class SoundPlayerUIState extends State<SoundPlayerUI> {
     } finally {
       _loading = false;
       _transitioning = false;
-      Log.d(green('Transitioning = false'));
     }
   }
 


### PR DESCRIPTION
Thanks for this sounds package! It's very useful.

I ran into an issue when using `SoundPlayerUI` in one of my app.

When the sound is playing, and navigator happens (i.e. back to previous screen), the sound would keep on playing in the background.

Assertion error is thrown on `dispose()`, but it was not the culprit (I asked a question [here](https://github.com/flutter/flutter/issues/64935) to flutter team). I found the handling of `async/await` in SoundPlayerUI is not consistent and could hide more issues than the one I ran into.

Before I recognised, I ended up rewrote all `.then().catchError()` into normal `try... catch...` with `async/await` :P 

This fixed the issue that sound left playing in background for me.

I ran into another issue when I paused the player, switch to another app, then switch back, click resume, `ERR_PLAYER_IS_NULL` was thrown from the platform invocation. Will try to look at it later