### PR TITLE
Export PlayerInvalidStateException for user to catch it properly

### DIFF
--- a/lib/sounds.dart
+++ b/lib/sounds.dart
@@ -41,7 +41,7 @@ export 'src/media_format/well_know_media_formats.dart';
 export 'src/quick_play.dart' show QuickPlay;
 export 'src/recording_disposition.dart' show RecordingDisposition;
 export 'src/sound_player.dart'
-    show SoundPlayer
+    show SoundPlayer, PlayerInvalidStateException
     hide
         updateProgress,
         audioPlayerFinished,


### PR DESCRIPTION
This is inline with the RecorderInvalidStateException which has been
exported already