### PR TITLE
Export AudioSource and Quality use with SoundRecorder.record.

### DIFF
--- a/lib/sounds.dart
+++ b/lib/sounds.dart
@@ -55,3 +55,5 @@ export 'src/ui/recorder_playback_controller.dart'
     show RecorderPlaybackController;
 export 'src/ui/sound_player_ui.dart' show SoundPlayerUI;
 export 'src/ui/sound_recorder_ui.dart' show SoundRecorderUI;
+export 'src/audio_source.dart' show AudioSource;
+export 'src/quality.dart' show Quality;


### PR DESCRIPTION
SoundRecorder:record has parameters of type AudioSource and Quality which weren't exported by the package.