### PR TITLE
Fix not playing audio on iOS for some local paths

### DIFF
--- a/ios/Classes/ShadePlayer.swift
+++ b/ios/Classes/ShadePlayer.swift
@@ -34,8 +34,8 @@ import MediaPlayer
 /// Allows playback control even when the phone is locked.
 private var _channel: FlutterMethodChannel?
 
-func ShadePlayerReg(_ registrar: (NSObjectProtocol & FlutterPluginRegistrar)?) {
-    ShadePlayerManager.register(with: registrar!)
+func ShadePlayerReg(_ registrar: FlutterPluginRegistrar) {
+    ShadePlayerManager.register(with: registrar)
 }
 
 var shadePlayerManager: ShadePlayerManager? // Singleton
@@ -67,7 +67,7 @@ class ShadePlayerManager: SoundPlayerManager {
         return shadePlayerManager
     }
 
-    override func handle(_ call: FlutterMethodCall?, result: FlutterResult) {
+    override func handle(_ call: FlutterMethodCall?, result: @escaping FlutterResult) {
         let args = call?.arguments as! Dictionary<String, Any>
         var slotNo = (args["slotNo"] as? NSNumber)?.intValue ?? 0
 
@@ -99,7 +99,7 @@ class ShadePlayerManager: SoundPlayerManager {
         } else if "startShadePlayer" == call?.method {
             aShadePlayer?.start(call: call, result: result)
         } else {
-            super.handle(call, result: result)
+            super.handle(call!, result: result)
         }
     }
 }

--- a/ios/Classes/SoundPlayer.swift
+++ b/ios/Classes/SoundPlayer.swift
@@ -22,14 +22,10 @@ import Flutter
 // These slots are shared by the SoundPlayer and the ShadePlayer.private var _channel: FlutterMethodChannel?
 var playerSlots: [AnyHashable]?
 
-func SoundPlayerReg(_ registrar: (NSObjectProtocol & FlutterPluginRegistrar)) {
-}
-
 var soundPlayerManager: SoundPlayerManager? // Singleton
 
-
-func SoundPlayerReg(_ registrar: (NSObjectProtocol & FlutterPluginRegistrar)?) {
-    SoundPlayerManager.register(with: registrar as! FlutterPluginRegistrar)
+func SoundPlayerReg(_ registrar: FlutterPluginRegistrar) {
+    SoundPlayerManager.register(with: registrar)
 }
 
 
@@ -50,8 +46,8 @@ class SoundPlayerManager: NSObject, FlutterPlugin {
 
     }
 
-    func handle(_ call: FlutterMethodCall?, result: FlutterResult) {
-        let args = call?.arguments as! Dictionary<String, Any>
+    func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let args = call.arguments as! Dictionary<String, Any>
         let slotNo = (args["slotNo"] as? NSNumber)?.intValue ?? 0
         // The dart code supports lazy initialization of players.
         // This means that players can be registered (and slots allocated)
@@ -65,52 +61,52 @@ class SoundPlayerManager: NSObject, FlutterPlugin {
         }
 
         var aSoundPlayer = playerSlots?[slotNo] as? SoundPlayer
-        if "initializeMediaPlayer" == call?.method {
+        if "initializeMediaPlayer" == call.method {
             assert(playerSlots?[slotNo] == nil)
             aSoundPlayer = SoundPlayer(aSlotNo: slotNo)
             playerSlots?[slotNo] = aSoundPlayer
             aSoundPlayer?.initializeSoundPlayer(call, result: result)
-        } else if "releaseMediaPlayer" == call?.method {
+        } else if "releaseMediaPlayer" == call.method {
             aSoundPlayer?.release(call, result: result)
             playerSlots?[slotNo] = NSNull()
             playerSlots?[slotNo] = NSNull()
-        } else if "getDuration" == call?.method {
+        } else if "getDuration" == call.method {
             //assert(args != nil)
             let path = args["path"] as! String
             let callbackUuid = args["callbackUuid"] as? String
             soundPlayerManager?.getDuration(path, callbackUuid: callbackUuid, slotNo: slotNo, result: result)
-        } else if "startPlayer" == call?.method {
+        } else if "startPlayer" == call.method {
             let path = args["path"] as? String
             aSoundPlayer?.start(path, result: result)
-        } else if "startPlayerFromBuffer" == call?.method {
+        } else if "startPlayerFromBuffer" == call.method {
             let dataBuffer = args["dataBuffer"] as? FlutterStandardTypedData
             aSoundPlayer?.start(fromBuffer: dataBuffer, result: result)
-        } else if "stopPlayer" == call?.method {
+        } else if "stopPlayer" == call.method {
             aSoundPlayer?.stop()
             result("stop play")
-        } else if "pausePlayer" == call?.method {
+        } else if "pausePlayer" == call.method {
             aSoundPlayer?.pause(result)
-        } else if "resumePlayer" == call?.method {
+        } else if "resumePlayer" == call.method {
             aSoundPlayer?.resumePlayer(result)
-        } else if "seekToPlayer" == call?.method {
+        } else if "seekToPlayer" == call.method {
             let positionInMilli = args["milli"] as? NSNumber
             aSoundPlayer?.seek(toPlayer: positionInMilli?.intValue ?? 0, result: result)
-        } else if "setProgressInterval" == call?.method {
+        } else if "setProgressInterval" == call.method {
             let intervalInMilli = args["milli"] as? NSNumber
             aSoundPlayer?.setProgressInterval(intervalInMilli?.intValue ?? 0, result: result)
-        } else if "setVolume" == call?.method {
+        } else if "setVolume" == call.method {
             let volume = args["volume"] as? NSNumber
             aSoundPlayer?.setVolume(volume?.doubleValue ?? 0.0, result: result)
-        } else if "iosSetCategory" == call?.method {
+        } else if "iosSetCategory" == call.method {
             //assert(args != nil)
             let categ = args["category"] as? String
             let mode = args["mode"] as? String
             let options = args["options"] as? NSNumber
             aSoundPlayer?.setCategory(categ, mode: mode, options: options?.intValue ?? 0, result: result)
-        } else if "setActive" == call?.method {
+        } else if "setActive" == call.method {
             let enabled = (args["enabled"] as? NSNumber)?.boolValue ?? false
             aSoundPlayer?.setActive(enabled, result: result)
-        } else if "getResourcePath" == call?.method {
+        } else if "getResourcePath" == call.method {
             result(Bundle.main.resourcePath)
         } else {
             result(FlutterMethodNotImplemented)
@@ -143,7 +139,7 @@ class SoundPlayerManager: NSObject, FlutterPlugin {
             let milliseconds = Int(outDataSize * 1000)
 
             let args = String(
-                format: "{\"callbackUuid\": \"%@\", \"milliseconds\": %d}", callbackUuid as! CVarArg, milliseconds)
+                format: "{\"callbackUuid\": \"%@\", \"milliseconds\": %d}", callbackUuid!, milliseconds)
 
             let dic = [
                 "slotNo": NSNumber(value: Int32(slotNo)),
@@ -153,7 +149,7 @@ class SoundPlayerManager: NSObject, FlutterPlugin {
         } else {
             /// danger will robison, danger
             let args = String(
-                format: "{\"callbackUuid\": \"%@\", \"description\": \"%d\"}", callbackUuid as! CVarArg, Int(status))
+                format: "{\"callbackUuid\": \"%@\", \"description\": \"%d\"}", callbackUuid!, Int(status))
             let dic = [
                 "slotNo": NSNumber(value: Int32(slotNo)),
                 "arg": args
@@ -336,6 +332,7 @@ class SoundPlayer: NSObject, AVAudioPlayerDelegate {
         }
     }
 
+    @discardableResult
     func resume() -> Bool {
         isPaused = true
 
@@ -360,7 +357,7 @@ class SoundPlayer: NSObject, AVAudioPlayerDelegate {
         return b
     }
 
-    func start(_ path: String?, result: FlutterResult) {
+    func start(_ path: String?, result: @escaping FlutterResult) {
         var isRemote = false
         if NSString.self == NSNull.self {
             audioFileURL = URL(fileURLWithPath: (getDirectoryOfType_Sounds(.cachesDirectory) ?? "") + "sound.aac")
@@ -414,7 +411,7 @@ class SoundPlayer: NSObject, AVAudioPlayerDelegate {
                         let b = self.audioPlayer?.play() ?? false
                         if !b {
                             self.stop()
-                            (FlutterError(
+                            result(FlutterError(
                                 code: "Audio Player",
                                 message: "Play failure",
                                 details: nil))
@@ -439,7 +436,7 @@ class SoundPlayer: NSObject, AVAudioPlayerDelegate {
             let b = audioPlayer?.play() ?? false
             if !b {
                 stop()
-                (FlutterError(
+                result(FlutterError(
                     code: "Audio Player",
                     message: "Play failure",
                     details: nil))
@@ -480,7 +477,7 @@ class SoundPlayer: NSObject, AVAudioPlayerDelegate {
         let b = audioPlayer?.play() ?? false
         if !b {
             stop()
-            (FlutterError(
+            result(FlutterError(
                 code: "Audio Player",
                 message: "Play failure",
                 details: nil))

--- a/ios/Classes/SoundPlayer.swift
+++ b/ios/Classes/SoundPlayer.swift
@@ -370,7 +370,7 @@ class SoundPlayer: NSObject, AVAudioPlayerDelegate {
                 audioFileURL = remoteUrl
                 isRemote = true
             } else {
-                audioFileURL = URL(string: path ?? "")
+                audioFileURL = remoteUrl ?? URL(fileURLWithPath: path ?? "", isDirectory: false)
             }
         }
         // Able to play in silent mode

--- a/ios/Classes/SoundRecorder.swift
+++ b/ios/Classes/SoundRecorder.swift
@@ -33,8 +33,8 @@ import Flutter
 private var _channel: FlutterMethodChannel?
 var _soundRecorderChannel: FlutterMethodChannel?
 
-func SoundRecorderReg(_ registrar: (NSObjectProtocol & FlutterPluginRegistrar)?) {
-    SoundRecorderManager.register(with: registrar!)
+func SoundRecorderReg(_ registrar: FlutterPluginRegistrar) {
+    SoundRecorderManager.register(with: registrar)
 }
 
 var soundRecorderManager: SoundRecorderManager? // Singleton
@@ -136,9 +136,9 @@ class SoundRecorder: NSObject, AVAudioRecorderDelegate {
         let bitRate = args?["bitRate"] as? NSNumber
         let formatArg = args?["format"] as? NSNumber
 
-        var sampleRate: Float = 44100
+        let sampleRate: Float = 44100
 
-        var numChannels = 2
+        let numChannels = 2
 
         let format = formatArg?.intValue ?? 0
 
@@ -190,7 +190,7 @@ class SoundRecorder: NSObject, AVAudioRecorderDelegate {
 
 
         do {
-            if let audioFileURL = audioFileURL, let audioSettings = audioSettings as? [String : Any] {
+            if let audioFileURL = audioFileURL {
                 audioRecorder = try AVAudioRecorder(
                     url: audioFileURL,
                     settings: audioSettings)

--- a/ios/Classes/Sounds.swift
+++ b/ios/Classes/Sounds.swift
@@ -50,8 +50,8 @@ enum t_SET_CATEGORY_DONE : Int {
     case by_USER // The caller did it himself : Sounds must not change that)
 }
 
-class Sounds: NSObject, FlutterPlugin, AVAudioPlayerDelegate {
-    class func register(with registrar: FlutterPluginRegistrar) {
+public class Sounds: NSObject, FlutterPlugin, AVAudioPlayerDelegate {
+    public class func register(with registrar: FlutterPluginRegistrar) {
         SoundPlayerReg(registrar)
         SoundRecorderReg(registrar)
         ShadePlayerReg(registrar)


### PR DESCRIPTION
When handing local system paths, a special constructor must be called on `URL`. See the official [documentation](https://developer.apple.com/documentation/foundation/nsurl/1414650-fileurl).

For example, without this fix 
`/Users/some-user/Library/Developer/CoreSimulator/Devices/828006A2-398A-40E6-B8C4-10D6974A84EA/data/Containers/Data/Application/005825E6-2EC9-45BD-9F9F-54EE3D3033D8/Library/Application Support/audio/some-audio-file` 

would result in `nil` being handed as a URL to `AVAudioPlayer`.

Unfortunately the project did not compile, so I applied some quick fixes as a second commit to this PR to make the project work.
The actual fix can be found in this [commit](https://github.com/bsutton/sounds/commit/7529ee396af6b365d5e13f0894160d3942b66394)


